### PR TITLE
Fix curl request in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ curl -X POST \
   http://localhost/oauth/token \
   -H ‘cache-control: no-cache’ \
   -H ‘content-type: application/x-www-form-urlencoded’ \
-  -d ‘client_id=<clientID>&client_secret=<secret>&grant_type=password&username=admin&password=<admin_password>’
+  -d ‘client_id=<clientID>&client_secret=<secret>&grant_type=password&scope=administrator&username=admin&password=<admin_password>’
 ``
 In the ``client_id`` section, you will need to set the following values:
 


### PR DESCRIPTION
On my setup, the request fetching the initial access and refresh tokens didn't work until I added the "scope" param

(seen on [the league/oauth2-server doc page](http://oauth2.thephpleague.com/authorization-server/resource-owner-password-credentials-grant/) linked from [drupal's simple_oauth project page](https://www.drupal.org/project/simple_oauth))